### PR TITLE
Basic threading support - WIP

### DIFF
--- a/bot.cfg
+++ b/bot.cfg
@@ -1,8 +1,9 @@
 # Server level configuration
 irc.host = "irc.unerror.com"
-irc.port = 6667
+irc.port = 6697
 irc.nick = "Quarid"
 irc.pass = ""
+irc.channels = "#goaway"
 
 # SSL configurations
 ssl.use = False

--- a/irc.py
+++ b/irc.py
@@ -175,7 +175,12 @@ class EventedIRC(event.Observer): # pylint: disable=too-many-public-methods
         channels = ''
         channels = channels.join(chans).replace('#', ',#')
         channels = channels[1:]
-        channel_keys = ", ".join(keys)
+		# Commenting out below for now as we will run this method once
+		# per channel
+        # channel_keys = ", ".join(keys)
+        channel_keys = keys
+        self.log.info(str("Joining channels: {0},{1}")
+                .format(channels, channel_keys))
         self.__send('JOIN %s %s' % (channels, channel_keys))
 
     def part(self, *chans):

--- a/irc.py
+++ b/irc.py
@@ -175,8 +175,8 @@ class EventedIRC(event.Observer): # pylint: disable=too-many-public-methods
         channels = ''
         channels = channels.join(chans).replace('#', ',#')
         channels = channels[1:]
-		# Commenting out below for now as we will run this method once
-		# per channel
+        # Commenting out below for now as we will run this method once
+        # per channel
         # channel_keys = ", ".join(keys)
         channel_keys = keys
         self.log.info(str("Joining channels: {0},{1}")

--- a/plugins/slap.py
+++ b/plugins/slap.py
@@ -2,6 +2,5 @@
 Slap module for Quarid
 """
 
-def register():
-	""" Register the 'slap' module with Quarid """
-
+def register(bot, conf):
+    """ Register the 'slap' module with Quarid """

--- a/plugins/urlget.py
+++ b/plugins/urlget.py
@@ -1,6 +1,6 @@
 """
 URLGet module for Quarid
 """
-def register():
+def register(bot, conf):
 	""" Register the 'urlget' module with Quarid"""
 	pass

--- a/quarid.py
+++ b/quarid.py
@@ -111,7 +111,7 @@ def stop():
 
 def qpirc(cfg_file):
     """
-    Start the bot, register it's modules and run the main loop
+    Start the bot, register its modules and run the main loop
     """
     conf = config.Config(cfg_file)
     bot = IRC.factory()
@@ -122,12 +122,10 @@ def qpirc(cfg_file):
         Log('plugins.log').logger.debug('Registering plugin %s', module)
 
         plugin_module = importlib.import_module("plugins.%s" % module)
-        # Below fails due to register() not taking any extra args
-        # plugin_module.register(bot, conf)
-        plugin_module.register()
+        plugin_module.register(bot, conf)
 
     print("Starting the bot...")
-    bot.connect(
+    connect_status = bot.connect(
         core['host'],
         core['port'],
         core['nick'],
@@ -135,7 +133,10 @@ def qpirc(cfg_file):
         conf.get('ssl')['use']
     )
     # Sleep while we connect - we may be able to get rid of this at some point
-    time.sleep(15)
+    while True:
+        time.sleep(5)
+        if connect_status is True:
+            break
     threads = []
 
     # Run the main loop listening for events

--- a/quarid.py
+++ b/quarid.py
@@ -8,6 +8,8 @@ import importlib
 import os
 import sys
 import signal
+from threading import Thread
+import time
 
 from irc import IRC
 from logger import Log
@@ -134,6 +136,9 @@ def qpirc(cfg_file):
     )
     # Sleep while we connect - we may be able to get rid of this at some point
     time.sleep(15)
+    threads = []
+
+    # Run the main loop listening for events
     threads.append(Thread(target=bot.run))
     for thread in threads:
         thread.setDaemon(True)


### PR DESCRIPTION
* Added basic threading support so the bot can run in the background so foreground operations can still happen (such as joining channels on bootup).
* Fixed channel key support. We will call `bot.join()` once per channel
instead of once for all channels. Some channels may not have keys (guess
`keys=None` could solve it) BUT on another hand some channels may have
different modes. Looping through channels solves the issue of setting
modes.

Definite TODO:

- [ ] Build graceful `disconnect()` method so we can avoid `The TLS connection was non-properly terminated.` quit message
- [ ] Cleanup channel join on bootup. I know this can be made cleaner. We also need to check whether we even want to connect to a channel on bootup
- [x] Figure out or add some sort of command triggering mechanism